### PR TITLE
Correctly output a newline after the `o skirt` object

### DIFF
--- a/main.c
+++ b/main.c
@@ -631,7 +631,7 @@ int convert( char *filename, char *mapname )
         // file2 << endl;
         fwrite( "\n", 1, 1, file2 );
     }
-    fwrite( "o skirt\n", 1, 7, file2);// << endl;
+    fwrite( "o skirt\n", 1, 8, file2);// << endl;
     for( usint x =0; x < Q+(R*2); x++ )
     {
         for( usint y = 0; y < 3; y++ )


### PR DESCRIPTION
The `fwrite` for the `o skirt` object header was not writing enough bytes. This caused the line to be written without a newline like so:

```obj
o skirtv 2.520000 0.720000 2.240000
```
instead of like so:
```obj
o skirt
v 2.520000 0.720000 2.240000
```

This caused all of the vertex indices to be off by one, making the very last face reference a non-existent vertex. It also caused all remaining faces to be very strange looking.

This fixes #2 . I got curious and decided to dig into it myself :)